### PR TITLE
feat(DEVEX-843): deleting external account when plaid flow interrupted/aborted

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bond-sdk-web",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "",
   "main": "dist/bond-sdk-web.js",
   "scripts": {

--- a/src/bond-sdk-external-accounts.ts
+++ b/src/bond-sdk-external-accounts.ts
@@ -172,7 +172,7 @@ class BondExternalAccounts {
                 externalAccounts: externalAccounts,
             };
         } else {
-            // TODO: await this._deleteExternalAccount(account_id, credentials);
+            await this._deleteExternalAccount(account_id, credentials);
             return {
                 status: "interrupted",
                 plaidResponse: (response as PlaidExitResponse),


### PR DESCRIPTION
When a `linkAccount` flow starts we create an account that "dangles" if we don't delete it if the Plaid flow is aborted. @andrewc-bond 's PR enables us to delete it. 

Reminder: Releases that get published to NPM need to include a built .js file in the /dist folder for non-standard implementations.
