### PR TITLE
chore(DEVEX-843): bump again, 0.0.10 may not have had delete (need automation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bond-sdk-web",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "",
   "main": "dist/bond-sdk-web.js",
   "scripts": {


### PR DESCRIPTION
Reminder: Releases that get published to NPM need to include a built .js file in the /dist folder for non-standard implementations.
